### PR TITLE
Fixes inconsistency with WPML

### DIFF
--- a/remove-category-url.php
+++ b/remove-category-url.php
@@ -69,7 +69,7 @@ function remove_category_url_rewrite_rules( $category_rewrite ) {
 
 		remove_filter( 'terms_clauses', array( $sitepress, 'terms_clauses' ) );
 		$categories = get_categories( array( 'hide_empty' => false, '_icl_show_all_langs' => true ) );
-		add_filter( 'terms_clauses', array( $sitepress, 'terms_clauses' ) );
+		add_filter( 'terms_clauses', array( $sitepress, 'terms_clauses' ), 10, 4 );
 	} else {
 		$categories = get_categories( array( 'hide_empty' => false ) );
 	}


### PR DESCRIPTION
Fixes the error `Too few arguments to function SitePress::terms_clauses()` in PHP >= 7.2, caused by an incorrect add_filter call.